### PR TITLE
fix: add 's' module.exports of react js

### DIFF
--- a/react.js
+++ b/react.js
@@ -1,6 +1,6 @@
 const rules = require('./rules');
 
-module.export = {
+module.exports = {
   'root': true,
 
   'env': {


### PR DESCRIPTION
react 规则不可用，exports 少个 s